### PR TITLE
build-snap: update canonical/setup-lxd to v0.1.1

### DIFF
--- a/build-snap/action.yml
+++ b/build-snap/action.yml
@@ -70,7 +70,7 @@ runs:
 
   - name: Set up LXD
     if: inputs.setup-lxd == 'true'
-    uses: canonical/setup-lxd@v0.1.0
+    uses: canonical/setup-lxd@v0.1.1
     with:
       channel: ${{ inputs.lxd-channel }}
 


### PR DESCRIPTION
There is a bug in canonical/setup-lxd@v0.1.0 where the `channel` input is ignored. This has been fixed in v0.1.1. See https://github.com/canonical/setup-lxd/pull/8