### PR TITLE
Changed files actions to substitute tj-actions/changed-files

### DIFF
--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -1,0 +1,34 @@
+name: Changed files
+description: Get list of changed files between two branches
+
+inputs:
+  base-branch:
+    description: Base branch (destination of a pull request)
+    required: true
+    default: ${{ github.base_ref }}
+  head-branch:
+    description: Head branch (source of a pull request)
+    required: true
+    default: ${{ github.head_ref }}
+
+outputs:
+  changed-files:
+    description: List of changed files
+    value: ${{ steps.changed-files.outputs.changed-files }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get changed files
+      id: changed-files
+      shell: bash
+      run: |
+        BASE_BRANCH=${{ inputs.base-branch }}
+        HEAD_BRANCH=${{ inputs.head-branch }}
+
+        CHANGED_FILES=$(git diff --name-only $BASE_BRANCH..$HEAD_BRANCH)
+        {
+          echo 'changed-files<<EOF'
+          echo "${CHANGED_FILES}"
+          echo EOF
+        } >> $GITHUB_OUTPUT

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: ${{ github.base_ref }}
   head-branch:
     description: Head branch (source of a pull request)
-    required: true
+    required: false
     default: ${{ github.head_ref }}
 
 outputs:
@@ -26,7 +26,9 @@ runs:
         BASE_BRANCH=${{ inputs.base-branch }}
         HEAD_BRANCH=${{ inputs.head-branch }}
 
-        CHANGED_FILES=$(git diff --name-only $BASE_BRANCH..$HEAD_BRANCH)
+        git fetch origin $BASE_BRANCH --depth 1
+        git fetch origin $HEAD_BRANCH --depth 1
+        CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH origin/$HEAD_BRANCH)
         {
           echo 'changed-files<<EOF'
           echo "${CHANGED_FILES}"

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -14,7 +14,7 @@ inputs:
 outputs:
   changed-files:
     description: List of changed files
-    value: ${{ steps.changed-files.outputs.changed-files }}
+    value: ${{ steps.changed-files.outputs.all_changed_files }}
 
 runs:
   using: composite
@@ -30,7 +30,7 @@ runs:
         git fetch origin $HEAD_BRANCH --depth 1
         CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH origin/$HEAD_BRANCH)
         {
-          echo 'changed-files<<EOF'
+          echo 'all_changed_files<<EOF'
           echo "${CHANGED_FILES}"
           echo EOF
         } >> $GITHUB_OUTPUT


### PR DESCRIPTION
I added an action that lists the changed files between to branches, to substitute uses of `tj-actions/changed-files` after the recent issue with vulnerabilities in that repository.