### PR TITLE
Fix `changed-files` action to work across forks

### DIFF
--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -22,8 +22,10 @@ runs:
         BASE_BRANCH=${{ inputs.base-branch }}
         git fetch origin $BASE_BRANCH --depth 1
 
+        echo "Changed files between $BASE_BRANCH and ${{ github.ref }}"
+
         cat <<END_OUTPUT >> $GITHUB_OUTPUT
         all_changed_files<<EOF
-        $( git diff --name-only origin/$BASE_BRANCH)
+        $( git diff --name-only origin/$BASE_BRANCH ${{ github.ref }})
         EOF
         END_OUTPUT

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Base branch (destination of a pull request)
     required: true
     default: ${{ github.base_ref }}
+  head-branch:
+    description: Head branch (source of a pull request)
+    required: false
+    default: ${{ github.head_ref }}
 
 outputs:
   changed-files:
@@ -20,11 +24,11 @@ runs:
       shell: bash
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
-        HEAD_BRANCH="pull/19/merge"
-        git fetch origin $BASE_BRANCH --depth 1
-        git fetch origin $HEAD_BRANCH --depth 1
+        HEAD_BRANCH=${{ inputs.head-branch }}
+        HEAD_REF=pull/${{ github.ref_name }}:$HEAD_BRANCH
 
-        echo $(git branch -l)
+        git fetch origin $BASE_BRANCH --depth 1
+        git fetch origin $HEAD_REF --depth 1
 
         echo "Changed files between $BASE_BRANCH and $HEAD_BRANCH"
 

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -20,13 +20,14 @@ runs:
       shell: bash
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
+        HEAD_BRANCH=${{ github.ref }}
         git fetch origin $BASE_BRANCH --depth 1
-        git fetch origin ${{ github.ref }} --depth 1
+        git fetch origin $HEAD_BRANCH --depth 1
 
-        echo "Changed files between $BASE_BRANCH and ${{ github.ref }}"
+        echo "Changed files between $BASE_BRANCH and $HEAD_BRANCH"
 
         cat <<END_OUTPUT >> $GITHUB_OUTPUT
         all_changed_files<<EOF
-        $( git diff --name-only origin/$BASE_BRANCH ${{ github.ref }})
+        $( git diff --name-only origin/$BASE_BRANCH origin/$HEAD_BRANCH)
         EOF
         END_OUTPUT

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -25,10 +25,9 @@ runs:
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
         HEAD_BRANCH=${{ inputs.head-branch }}
-        HEAD_COMMIT=$(git rev-parse HEAD)
-        echo "Head commit: $HEAD_COMMIT"
-        REPOSITORY=${{ github.server_url }}/${{ github.repository }}
-        echo "Repository: $REPOSITORY"
+        echo "BASE_REPO_URL=${{ github.event.pull_request.base.repo.html_url }}" >> $GITHUB_ENV
+        echo "HEAD_REPO_URL=${{ github.event.pull_request.head.repo.html_url }}" >> $GITHUB_ENV
+
 
         git fetch origin $BASE_BRANCH --depth 1
         # git fetch origin $HEAD_BRANCH --depth 1

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -9,7 +9,7 @@ inputs:
   head-branch:
     description: Head branch (source of a pull request)
     required: false
-    default: ${{ github.head_ref }}
+    default: ${{ github.ref }}
 
 outputs:
   changed-files:

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -28,7 +28,7 @@ runs:
         HEAD_REF=${{ github.ref }}:$HEAD_BRANCH
 
         git fetch origin $BASE_BRANCH --depth 1
-        git fetch origin $HEAD_REF --depth 1
+        git fetch origin $HEAD_BRANCH --depth 1
 
         cat <<END_OUTPUT >> $GITHUB_OUTPUT
         all_changed_files<<EOF

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -24,6 +24,8 @@ runs:
         git fetch origin $BASE_BRANCH --depth 1
         git fetch origin $HEAD_BRANCH --depth 1
 
+        echo $(git branch)
+
         echo "Changed files between $BASE_BRANCH and $HEAD_BRANCH"
 
         cat <<END_OUTPUT >> $GITHUB_OUTPUT

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -25,13 +25,15 @@ runs:
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
         HEAD_BRANCH=${{ inputs.head-branch }}
-        echo "BASE_REPO_URL=${{ github.event.pull_request.base.repo.html_url }}" >> $GITHUB_ENV
-        echo "HEAD_REPO_URL=${{ github.event.pull_request.head.repo.html_url }}" >> $GITHUB_ENV
+        BASE_REPO_URL=${{ github.event.pull_request.base.repo.html_url }}
 
+        # Add remote to head in case it's a fork
+        HEAD_REPO_URL=${{ github.event.pull_request.head.repo.html_url }}
+        git remote add head $HEAD_REPO_URL
 
         git fetch origin $BASE_BRANCH --depth 1
-        # git fetch origin $HEAD_BRANCH --depth 1
-        CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH) # origin/$HEAD_BRANCH)
+        git fetch head $HEAD_BRANCH --depth 1
+        CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH head/$HEAD_BRANCH)
         {
           echo 'all_changed_files<<EOF'
           echo "${CHANGED_FILES}"

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -20,9 +20,11 @@ runs:
       shell: bash
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
-        HEAD_BRANCH="HEAD"
+        HEAD_BRANCH="pull/19/merge"
         git fetch origin $BASE_BRANCH --depth 1
         git fetch origin $HEAD_BRANCH --depth 1
+
+        echo $(git branch -l)
 
         echo "Changed files between $BASE_BRANCH and $HEAD_BRANCH"
 

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -32,6 +32,6 @@ runs:
 
         cat <<END_OUTPUT >> $GITHUB_OUTPUT
         all_changed_files<<EOF
-        $( git diff --name-only origin/$BASE_BRANCH $HEAD_BRANCH)
+        $( git diff --name-only origin/$BASE_BRANCH $HEAD_BRANCH )
         EOF
         END_OUTPUT

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -21,6 +21,7 @@ runs:
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
         git fetch origin $BASE_BRANCH --depth 1
+        git fetch origin ${{ github.ref }} --depth 1
 
         echo "Changed files between $BASE_BRANCH and ${{ github.ref }}"
 

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -25,7 +25,7 @@ runs:
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
         HEAD_BRANCH=${{ inputs.head-branch }}
-        HEAD_REF=pull/${{ github.ref_name }}:$HEAD_BRANCH
+        HEAD_REF=${{ github.ref }}:$HEAD_BRANCH
 
         git fetch origin $BASE_BRANCH --depth 1
         git fetch origin $HEAD_REF --depth 1

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -29,7 +29,7 @@ runs:
         echo "Head commit: $HEAD_COMMIT"
 
         git fetch origin $BASE_BRANCH --depth 1
-        git fetch origin $HEAD_BRANCH --depth 1
+        # git fetch origin $HEAD_BRANCH --depth 1
         CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH) # origin/$HEAD_BRANCH)
         {
           echo 'all_changed_files<<EOF'

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -34,6 +34,6 @@ runs:
 
         cat <<END_OUTPUT >> $GITHUB_OUTPUT
         all_changed_files<<EOF
-        $( git diff --name-only origin/$BASE_BRANCH origin/$HEAD_BRANCH)
+        $( git diff --name-only origin/$BASE_BRANCH $HEAD_BRANCH)
         EOF
         END_OUTPUT

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -25,7 +25,6 @@ runs:
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
         HEAD_BRANCH=${{ inputs.head-branch }}
-        HEAD_REF=${{ github.ref }}:$HEAD_BRANCH
 
         git fetch origin $BASE_BRANCH --depth 1
         git fetch origin $HEAD_BRANCH --depth 1

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -30,8 +30,6 @@ runs:
         git fetch origin $BASE_BRANCH --depth 1
         git fetch origin $HEAD_REF --depth 1
 
-        echo "Changed files between $BASE_BRANCH and $HEAD_BRANCH"
-
         cat <<END_OUTPUT >> $GITHUB_OUTPUT
         all_changed_files<<EOF
         $( git diff --name-only origin/$BASE_BRANCH $HEAD_BRANCH)

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -25,6 +25,8 @@ runs:
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
         HEAD_BRANCH=${{ inputs.head-branch }}
+        HEAD_COMMIT=$(git rev-parse HEAD)
+        echo "Head commit: $HEAD_COMMIT"
 
         git fetch origin $BASE_BRANCH --depth 1
         git fetch origin $HEAD_BRANCH --depth 1

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -27,6 +27,8 @@ runs:
         HEAD_BRANCH=${{ inputs.head-branch }}
         HEAD_COMMIT=$(git rev-parse HEAD)
         echo "Head commit: $HEAD_COMMIT"
+        REPOSITORY=${{ github.server_url }}/${{ github.repository }}
+        echo "Repository: $REPOSITORY"
 
         git fetch origin $BASE_BRANCH --depth 1
         # git fetch origin $HEAD_BRANCH --depth 1

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -20,11 +20,9 @@ runs:
       shell: bash
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
-        HEAD_BRANCH=${{ github.ref }}
+        HEAD_BRANCH="HEAD"
         git fetch origin $BASE_BRANCH --depth 1
         git fetch origin $HEAD_BRANCH --depth 1
-
-        echo $(git branch -l)
 
         echo "Changed files between $BASE_BRANCH and $HEAD_BRANCH"
 

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: Base branch (destination of a pull request)
     required: true
     default: ${{ github.base_ref }}
-  head-branch:
-    description: Head branch (source of a pull request)
-    required: false
-    default: ${{ github.head_ref }}
 
 outputs:
   changed-files:
@@ -24,16 +20,9 @@ runs:
       shell: bash
       run: |
         BASE_BRANCH=${{ inputs.base-branch }}
-        HEAD_BRANCH=${{ inputs.head-branch }}
-        BASE_REPO_URL=${{ github.event.pull_request.base.repo.html_url }}
-
-        # Add remote to head in case it's a fork
-        HEAD_REPO_URL=${{ github.event.pull_request.head.repo.html_url }}
-        git remote add head $HEAD_REPO_URL
 
         git fetch origin $BASE_BRANCH --depth 1
-        git fetch head $HEAD_BRANCH --depth 1
-        CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH head/$HEAD_BRANCH)
+        CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH)
         {
           echo 'all_changed_files<<EOF'
           echo "${CHANGED_FILES}"

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -28,7 +28,7 @@ runs:
 
         git fetch origin $BASE_BRANCH --depth 1
         git fetch origin $HEAD_BRANCH --depth 1
-        CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH origin/$HEAD_BRANCH)
+        CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH) # origin/$HEAD_BRANCH)
         {
           echo 'all_changed_files<<EOF'
           echo "${CHANGED_FILES}"

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -24,7 +24,7 @@ runs:
         git fetch origin $BASE_BRANCH --depth 1
         git fetch origin $HEAD_BRANCH --depth 1
 
-        echo $(git branch)
+        echo $(git branch -l)
 
         echo "Changed files between $BASE_BRANCH and $HEAD_BRANCH"
 


### PR DESCRIPTION
The previous version of `changed-files` assumed a PR would be between two branches of the same repository. This caused issues when opening a PR across forks.

- I removed the explicit reference to the HEAD branch, which wouldn't exist in a cross-branch PR ("couldn't find remote ref").
- By default, the checkout action (which should be used before this one) fetches the HEAD branch of the PR, regardless of which fork it came from. So we can fetch the BASE (e.g. `main`) and compare it with the local state of the repo.
- I tried manually specifying the HEAD repository/branch using `github.event.pull_request.head.repo.html_url`, however this fails if the fork is not public.
- I tested this opening two PRs on a sample repository, one from a branch and one from a fork. Both produced the expected output.